### PR TITLE
Fix missing screenshot beep duration.

### DIFF
--- a/InsightLogParser.Client/Beeper.cs
+++ b/InsightLogParser.Client/Beeper.cs
@@ -40,7 +40,7 @@ internal class Beeper
     public void BeepForMissingScreenshot()
     {
         if (!_configuration.BeepForMissingScreenshot) return;
-        DoTheBeep(_configuration.MissingScreenshotBeepFrequency, _configuration.MissingScreenshotBeepFrequency);
+        DoTheBeep(_configuration.MissingScreenshotBeepFrequency, _configuration.MissingScreenshotBeepDuration);
     }
 
     public async Task BeepForAttentionAsync()


### PR DESCRIPTION
The missing screenshot beep duration was using the value in missing screenshot beep frequency.  This fixes that bug.