### PR TITLE
Add IncludeStalePuzzlesInRoutes option

### DIFF
--- a/InsightLogParser.Client/Configuration.cs
+++ b/InsightLogParser.Client/Configuration.cs
@@ -3,7 +3,7 @@ namespace InsightLogParser.Client;
 
 public class Configuration
 {
-    public static readonly int CurrentConfigurationVersion = 3;
+    public static readonly int CurrentConfigurationVersion = 4;
 
     public int ConfigVersion { get; set; } = CurrentConfigurationVersion;
 
@@ -41,4 +41,5 @@ public class Configuration
     public bool BeepForMissingScreenshot { get; set; }
     public int MissingScreenshotBeepFrequency { get; set; } = 440;
     public int MissingScreenshotBeepDuration { get; set; } = 150;
+    public bool IncludeStalePuzzlesInRoutes { get; set; } = true;
 }

--- a/InsightLogParser.Client/MainThing.cs
+++ b/InsightLogParser.Client/MainThing.cs
@@ -58,7 +58,7 @@ public class MainThing
         var teleportManager = new TeleportManager(_messageWriter);
 
         _messageWriter.WriteInitLine("Poking spider", ConsoleColor.Green);
-        var puzzleIterator = new PuzzleRouter(_messageWriter);
+        var puzzleIterator = new PuzzleRouter(_messageWriter, configuration);
         var serverTracker = new ServerTracker(_messageWriter);
         var spider = new Spider(_messageWriter, configuration, _db, _apiClient, _timeTools, _puzzleHandler, computer, teleportManager, puzzleIterator, serverTracker);
 

--- a/InsightLogParser.Client/Routing/PuzzleRouter.cs
+++ b/InsightLogParser.Client/Routing/PuzzleRouter.cs
@@ -8,13 +8,15 @@ internal class PuzzleRouter
     private const int MaxPuzzlesPerQuadrant = 10;
 
     private readonly MessageWriter _writer;
+    private readonly Configuration _configuration;
     private List<RouteNode> _sequence = [];
     private int? _sequenceIndex;
     private HashSet<int> _solvedForCurrentRoute = new();
 
-    public PuzzleRouter(MessageWriter writer)
+    public PuzzleRouter(MessageWriter writer, Configuration configuration)
     {
         _writer = writer;
+        _configuration = configuration;
     }
 
     private IEnumerable<Quadrant> Divide(Quadrant outer)
@@ -128,7 +130,7 @@ internal class PuzzleRouter
     public void SetRoute(IEnumerable<RouteNode> puzzles, Coordinate startCoordinate)
     {
         var valid = puzzles
-            .Where(x => x.Puzzle.PrimaryCoordinate != null)
+            .Where(x => x.Puzzle.PrimaryCoordinate != null && (_configuration.IncludeStalePuzzlesInRoutes || !(x.Stale.HasValue && x.Stale.Value)))
             .ToList();
 
         if (valid.Count == 0)


### PR DESCRIPTION
I found that a vast majority of the time, stale puzzles just didn't exist in my game.  So, I added an option to take it out.  Setting the option to false filters out puzzles that both have a stale value AND that value is true, since that field is a `bool?`.  The option defaults to true, so current behavior should remain for players that don't want to change it.

Note this bumps the config version to `4`.